### PR TITLE
findAccount required params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target/
 *.iml
 .idea/
+.project
+.classpath
+.settings
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -146,13 +146,13 @@
         </executions>
       </plugin>
       <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.0</version>
-            <configuration>
-                <release>11</release>
-            </configuration>
-        </plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+          <configuration>
+            <release>11</release>
+          </configuration>
+      </plugin>
     </plugins>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.0</version>
+            <configuration>
+                <release>11</release>
+            </configuration>
+        </plugin>
     </plugins>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
       <plugins>

--- a/src/main/java/com/kubacki/domain/TastingService.java
+++ b/src/main/java/com/kubacki/domain/TastingService.java
@@ -1,6 +1,7 @@
 package com.kubacki.domain;
 
 import com.kubacki.domain.repo.TastingRepo;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
@@ -19,9 +20,15 @@ public class TastingService {
     }
 
     public Account findAccount(String accountId, String firstName, String lastName, String email) {
-        if(accountId != null) {
+        if(!StringUtils.isBlank(accountId)) {
             return repo.getAccount(accountId);
         }
+
+        if(StringUtils.isBlank(email)) {
+            mustNotBeEmpty(firstName, "firstName");
+            mustNotBeEmpty(lastName, "lastName");
+        }
+
         return repo.findAccount(firstName, lastName, email);
     }
 
@@ -102,5 +109,12 @@ public class TastingService {
             throw new IllegalStateException("This beer was not found");
         }
         repo.addRating(foundAccount, foundBeer, Calendar.getInstance().get(Calendar.YEAR), rating);
+    }
+
+    private String mustNotBeEmpty(String value, String type) {
+        if(StringUtils.isBlank(value)) {
+            throw new IllegalArgumentException("Must have a value for " + type);
+        }
+        return value;
     }
 }

--- a/src/main/java/com/kubacki/domain/repo/TastingRepo.java
+++ b/src/main/java/com/kubacki/domain/repo/TastingRepo.java
@@ -61,7 +61,11 @@ public class TastingRepo extends JdbcTemplate {
 
     public Account getAccount(String accountId) {
         Object[] params = new Object[] {accountId};
-        return this.queryForObject(GET_ACCOUNT, params, new AccountMapper());
+        List<Account> accounts = this.query(GET_ACCOUNT, params, new AccountMapper());
+        if(accounts.isEmpty()) {
+            return null;
+        }
+        return accounts.get(0);
     }
 
     public String addBeer(Beer beer) {

--- a/src/main/java/com/kubacki/rest/AccountController.java
+++ b/src/main/java/com/kubacki/rest/AccountController.java
@@ -59,24 +59,42 @@ public class AccountController {
 
     @RequestMapping(value = "/find", method = RequestMethod.POST)
     public FoundAccountResponse find(@RequestBody FindAccountRequest request) {
-
-        Account account = service.findAccount(request.getAccountId(), request.getFirstName(),
-                    request.getLastName(), request.getEmail());
         FoundAccountResponse response = new FoundAccountResponse();
+        
+        try {
+            Account account = service.findAccount(request.getAccountId(), request.getFirstName(),
+                        request.getLastName(), request.getEmail());
 
-        if (account == null) {
-            log.info("account was not found: " + request);
-            response.setCode(404);
-            response.setPayload("The account was not found");
+            if (account == null) {
+                log.info("account was not found: " + request);
+                response.setCode(404);
+                response.setPayload("The account was not found");
+                return response;
+            }
+
+            response.setId(account.getId());
+            response.setFirstName(account.getFirstName());
+            response.setLastName(account.getLastName());
+            response.setEmail(account.getEmail());
+            response.setCode(200);
+            return response;
+
+        } catch (IllegalArgumentException e) {
+            log.error("handling error", e);
+            response.setCode(400);
+            response.setPayload(e.getMessage());
+            return response;
+        } catch (IllegalStateException e) {
+            log.error("handling error", e);
+            response.setCode(409);
+            response.setPayload(e.getMessage());
+            return response;
+        } catch (Exception e) {
+            // Catch any kind of unknown exception
+            response.setCode(500);
+            response.setPayload("Internal Server Error");
             return response;
         }
-
-        response.setId(account.getId());
-        response.setFirstName(account.getFirstName());
-        response.setLastName(account.getLastName());
-        response.setEmail(account.getEmail());
-        response.setCode(200);
-        return response;
     }
 
     @RequestMapping(value = "/beer", method = RequestMethod.POST)

--- a/src/main/resources/application-cfg.properties
+++ b/src/main/resources/application-cfg.properties
@@ -1,6 +1,6 @@
 # DataSource (H2)
 db.database-driver=org.h2.Driver
 #db.url.template = jdbc:h2:tcp://<server>[:<port>]/[<path>]<databaseName>
-db.url=jdbc:h2:tcp://localhost/~/TastingOfTheHops-Database/tasting
+db.url=jdbc:h2:tcp://localhost/~/git/hops/Database/tasting
 db.username=sa
 db.password=

--- a/src/test/java/com/kubacki/IntegrationTests.java
+++ b/src/test/java/com/kubacki/IntegrationTests.java
@@ -204,8 +204,36 @@ public class IntegrationTests {
     }
 
     @Test
+    public void testFindUser_withMissingRequiredFirstName_shouldReturn400NotFound() {
+        FindAccountRequest request = new FindAccountRequest();
+
+        FoundAccountResponse response = accountController.find(request);
+        assertThat(response.getId(), is(nullValue()));
+        assertThat(response.getFirstName(), is(nullValue()));
+        assertThat(response.getLastName(), is(nullValue()));
+        assertThat(response.getEmail(), is(nullValue()));
+        assertThat(response.getCode(), is(equalTo(400)));
+        assertThat(response.getPayload(), is(equalTo("Must have a value for firstName")));
+    }
+
+    @Test
+    public void testFindUser_withMissingRequiredLastName_shouldReturn400NotFound() {
+        FindAccountRequest request = new FindAccountRequest();
+        request.setFirstName(FIRST_NAME);
+
+        FoundAccountResponse response = accountController.find(request);
+        assertThat(response.getId(), is(nullValue()));
+        assertThat(response.getFirstName(), is(nullValue()));
+        assertThat(response.getLastName(), is(nullValue()));
+        assertThat(response.getEmail(), is(nullValue()));
+        assertThat(response.getCode(), is(equalTo(400)));
+        assertThat(response.getPayload(), is(equalTo("Must have a value for lastName")));
+    }
+
+    @Test
     public void testFindUser_thatDoesNotExist_shouldReturn404NotFound() {
         FindAccountRequest request = new FindAccountRequest();
+        request.setAccountId("THIS_ACCOUNT_DOES_NOT_EXIST");
 
         FoundAccountResponse response = accountController.find(request);
         assertThat(response.getId(), is(nullValue()));


### PR DESCRIPTION
Implemented logic into findAccount to require firstName and lastName if missing accountId and email.

Fixed getAccount query. queryForObject requires at least one entry to be returned, so fails when getAccount has an id that doesnt exist.

Updated tests to reflect new logic & bugfix.